### PR TITLE
[spike] use plotter for bulding context maps

### DIFF
--- a/src/main/java/com/glovoapp/ownership/OwnershipAnnotationDefinition.java
+++ b/src/main/java/com/glovoapp/ownership/OwnershipAnnotationDefinition.java
@@ -8,6 +8,7 @@ import static lombok.AccessLevel.PRIVATE;
 import com.glovoapp.ownership.shared.Pair;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.AnnotatedElement;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/com/glovoapp/ownership/OwnershipAnnotationDefinition.java
+++ b/src/main/java/com/glovoapp/ownership/OwnershipAnnotationDefinition.java
@@ -1,7 +1,6 @@
 package com.glovoapp.ownership;
 
 import static java.util.Collections.emptyMap;
-import static java.util.Collections.emptySet;
 import static java.util.stream.Collectors.toMap;
 import static lombok.AccessLevel.PACKAGE;
 import static lombok.AccessLevel.PRIVATE;
@@ -55,10 +54,10 @@ public interface OwnershipAnnotationDefinition {
                                                                        @NonNull final Function<A, ?> ownerGetter,
                                                                        @NonNull final Function<A, Map<String, ?>> metaDataGetter) {
         return givenElement -> {
-            Optional<A> a = Optional.ofNullable(givenElement).map(it -> extraceAnnoation(it, annotationClass));
+            Optional<A> a = Optional.ofNullable(givenElement).map(it -> extractAnnoation(it, annotationClass));
 
             if (!a.isPresent()) {
-                return Optional.of(new OwnershipData("nobody", emptyMap()));
+                return Optional.of(new OwnershipData("UNKNOWN", emptyMap()));
             }
             return a.map(annotation -> {
                 try {
@@ -73,7 +72,9 @@ public interface OwnershipAnnotationDefinition {
         };
     }
 
-    static  <A extends Annotation> A extraceAnnoation (AnnotatedElement it, Class<A> annotationClass) {
+    //TODO split it in a separate class, provide two strategies: strict (doesnt return ownersip info if annotation not present
+    //and inclusive (retuns a fallback ownership info for not anotated classes
+    static  <A extends Annotation> A extractAnnoation(AnnotatedElement it, Class<A> annotationClass) {
         try {
             return Optional.of(annotationClass)
                     .map(it::getAnnotation)

--- a/src/test/java/com/glovoapp/ownership/example2/OwnerWithContextAnnotation.java
+++ b/src/test/java/com/glovoapp/ownership/example2/OwnerWithContextAnnotation.java
@@ -1,0 +1,13 @@
+package com.glovoapp.ownership.example2;
+
+
+import java.lang.annotation.*;
+
+@Inherited
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.PACKAGE})
+public @interface OwnerWithContextAnnotation {
+
+    String owner() default "nobody";
+    String boundedContext() default "none";
+}

--- a/src/test/java/com/glovoapp/ownership/example2/downstreamcontext/DownstreamContextService.java
+++ b/src/test/java/com/glovoapp/ownership/example2/downstreamcontext/DownstreamContextService.java
@@ -1,14 +1,13 @@
 package com.glovoapp.ownership.example2.downstreamcontext;
 
-import com.glovoapp.ownership.example2.OwnerWithContextAnnotation;
-import com.glovoapp.ownership.example2.unknowncontext.Unknowclass;
+import com.glovoapp.ownership.example2.unknowncontext.UnknownClass;
 import com.glovoapp.ownership.example2.upstreamcontext.UpstreamContextService;
 
 
 public class DownstreamContextService {
 
     private UpstreamContextService dep = new UpstreamContextService();
-    private Unknowclass haha = new Unknowclass();
+    private UnknownClass unknown = new UnknownClass();
 
     public void execute() {
         dep.execute();

--- a/src/test/java/com/glovoapp/ownership/example2/downstreamcontext/DownstreamContextService.java
+++ b/src/test/java/com/glovoapp/ownership/example2/downstreamcontext/DownstreamContextService.java
@@ -1,12 +1,14 @@
 package com.glovoapp.ownership.example2.downstreamcontext;
 
 import com.glovoapp.ownership.example2.OwnerWithContextAnnotation;
+import com.glovoapp.ownership.example2.unknowncontext.Unknowclass;
 import com.glovoapp.ownership.example2.upstreamcontext.UpstreamContextService;
 
 
 public class DownstreamContextService {
 
     private UpstreamContextService dep = new UpstreamContextService();
+    private Unknowclass haha = new Unknowclass();
 
     public void execute() {
         dep.execute();

--- a/src/test/java/com/glovoapp/ownership/example2/downstreamcontext/DownstreamContextService.java
+++ b/src/test/java/com/glovoapp/ownership/example2/downstreamcontext/DownstreamContextService.java
@@ -1,0 +1,16 @@
+package com.glovoapp.ownership.example2.downstreamcontext;
+
+import com.glovoapp.ownership.example2.OwnerWithContextAnnotation;
+import com.glovoapp.ownership.example2.upstreamcontext.UpstreamContextService;
+
+
+public class DownstreamContextService {
+
+    private UpstreamContextService dep = new UpstreamContextService();
+
+    public void execute() {
+        dep.execute();
+    }
+
+
+}

--- a/src/test/java/com/glovoapp/ownership/example2/downstreamcontext/InternalDownstreamClass.java
+++ b/src/test/java/com/glovoapp/ownership/example2/downstreamcontext/InternalDownstreamClass.java
@@ -1,0 +1,4 @@
+package com.glovoapp.ownership.example2.downstreamcontext;
+
+public class InternalDownstreamClass {
+}

--- a/src/test/java/com/glovoapp/ownership/example2/downstreamcontext/package-info.java
+++ b/src/test/java/com/glovoapp/ownership/example2/downstreamcontext/package-info.java
@@ -1,0 +1,4 @@
+@OwnerWithContextAnnotation(boundedContext = "downstream")
+package com.glovoapp.ownership.example2.downstreamcontext;
+
+import com.glovoapp.ownership.example2.OwnerWithContextAnnotation;

--- a/src/test/java/com/glovoapp/ownership/example2/unknowncontext/AnotherUnknownClass.java
+++ b/src/test/java/com/glovoapp/ownership/example2/unknowncontext/AnotherUnknownClass.java
@@ -1,4 +1,4 @@
 package com.glovoapp.ownership.example2.unknowncontext;
 
-public class Unknowclass {
+public class AnotherUnknownClass {
 }

--- a/src/test/java/com/glovoapp/ownership/example2/unknowncontext/Unknowclass.java
+++ b/src/test/java/com/glovoapp/ownership/example2/unknowncontext/Unknowclass.java
@@ -1,0 +1,4 @@
+package com.glovoapp.ownership.example2.unknowncontext;
+
+public class Unknowclass {
+}

--- a/src/test/java/com/glovoapp/ownership/example2/unknowncontext/UnknownClass.java
+++ b/src/test/java/com/glovoapp/ownership/example2/unknowncontext/UnknownClass.java
@@ -1,0 +1,8 @@
+package com.glovoapp.ownership.example2.unknowncontext;
+
+import com.glovoapp.ownership.example2.downstreamcontext.DownstreamContextService;
+
+public class UnknownClass {
+
+    private AnotherUnknownClass down = new AnotherUnknownClass();
+}

--- a/src/test/java/com/glovoapp/ownership/example2/upstreamcontext/UpstreamContextService.java
+++ b/src/test/java/com/glovoapp/ownership/example2/upstreamcontext/UpstreamContextService.java
@@ -1,7 +1,6 @@
 package com.glovoapp.ownership.example2.upstreamcontext;
 
 import com.glovoapp.ownership.example2.OwnerWithContextAnnotation;
-import com.glovoapp.ownership.example2.unknowncontext.Unknowclass;
 
 @OwnerWithContextAnnotation(boundedContext = "upstream" )
 public class UpstreamContextService {

--- a/src/test/java/com/glovoapp/ownership/example2/upstreamcontext/UpstreamContextService.java
+++ b/src/test/java/com/glovoapp/ownership/example2/upstreamcontext/UpstreamContextService.java
@@ -1,0 +1,10 @@
+package com.glovoapp.ownership.example2.upstreamcontext;
+
+import com.glovoapp.ownership.example2.OwnerWithContextAnnotation;
+
+@OwnerWithContextAnnotation(boundedContext = "upstream" )
+public class UpstreamContextService {
+    public UpstreamValueObject execute() {
+        return new UpstreamValueObject();
+    }
+}

--- a/src/test/java/com/glovoapp/ownership/example2/upstreamcontext/UpstreamContextService.java
+++ b/src/test/java/com/glovoapp/ownership/example2/upstreamcontext/UpstreamContextService.java
@@ -1,9 +1,12 @@
 package com.glovoapp.ownership.example2.upstreamcontext;
 
 import com.glovoapp.ownership.example2.OwnerWithContextAnnotation;
+import com.glovoapp.ownership.example2.unknowncontext.Unknowclass;
 
 @OwnerWithContextAnnotation(boundedContext = "upstream" )
 public class UpstreamContextService {
+
+
     public UpstreamValueObject execute() {
         return new UpstreamValueObject();
     }

--- a/src/test/java/com/glovoapp/ownership/example2/upstreamcontext/UpstreamValueObject.java
+++ b/src/test/java/com/glovoapp/ownership/example2/upstreamcontext/UpstreamValueObject.java
@@ -1,0 +1,4 @@
+package com.glovoapp.ownership.example2.upstreamcontext;
+
+public class UpstreamValueObject {
+}

--- a/src/test/java/com/glovoapp/ownership/plotting/ClassOwnershipPlotterTest.java
+++ b/src/test/java/com/glovoapp/ownership/plotting/ClassOwnershipPlotterTest.java
@@ -134,6 +134,7 @@ class ClassOwnershipPlotterTest {
                 DomainOwnershipFilter.simple(
                         isADependencyOfAClassThat(isOwnedBy(desiredContext))
                                 .or(hasDependenciesWithOwnerOtherThan(desiredContext))
+                                .or(hasDependenciesOwnedBy("nobody"))
 
                 ),
                 packageDiagramePipeline()

--- a/src/test/java/com/glovoapp/ownership/plotting/ClassOwnershipPlotterTest.java
+++ b/src/test/java/com/glovoapp/ownership/plotting/ClassOwnershipPlotterTest.java
@@ -124,24 +124,17 @@ class ClassOwnershipPlotterTest {
         new ClassOwnershipPlotter(
                 new ReflectionsClasspathLoader(),
                 new AnnotationBasedClassOwnershipExtractor(define(OwnerWithContextAnnotation.class, OwnerWithContextAnnotation::boundedContext)),
-/*                DomainOwnershipFilter.simple(
-                        isOwnedBy(desiredContext)
-                                //.or(hasDependenciesOwnedBy(desiredContext))
-                                .or(isADependencyOfAClassThat(isOwnedBy(desiredContext)))
-                ),
-
-*/
                 DomainOwnershipFilter.simple(
                         isADependencyOfAClassThat(isOwnedBy(desiredContext))
                                 .or(hasDependenciesWithOwnerOtherThan(desiredContext))
                                 .or(hasDependenciesOwnedBy("nobody"))
 
                 ),
-                packageDiagramePipeline()
+                packageDiagramPipeline()
         ).createClasspathDiagram("com.glovoapp.ownership.example2");
     }
 
-    private static OwnershipDiagramPipeline packageDiagramePipeline() {
+    private static OwnershipDiagramPipeline packageDiagramPipeline() {
         return OwnershipDiagramPipeline.of(
                 new PlantUMLIdentifierGenerator(),
                 new RelationshipsDiagramDataFactory(),


### PR DESCRIPTION
not meant to be merged, just to show some of the changes that can be done to make a simple version of a context map diagram using ownership-plotter

![image](https://user-images.githubusercontent.com/53642942/135747533-4cbcf1c7-4abf-4fc3-b1a5-87ac63551e87.png)

### Follow ups
*  use metadata as ownership flag or introduce an explicit concept of "boundedContext" in the library
*  push code changes for supporting bounded context ownership display
* experiment it on monolith
*  print context map for outgoing/ingoing deps for each team